### PR TITLE
Fixed line counting for NCBI workflow

### DIFF
--- a/.github/workflows/ncbi.yml
+++ b/.github/workflows/ncbi.yml
@@ -138,15 +138,15 @@ jobs:
           removed=$removed_filtered
           # count them
           echo Counting differences:
-          count_removed=$(echo "$removed" | wc -l) || true
-          count_added=$(echo "$added" | wc -l) || true
+          count_removed=$(printf "$removed" | wc -l) || true
+          count_added=$(printf "$added" | wc -l) || true
 
           # make sure we are not counting empty lines
           if [ -z "$removed" ]; then
-           count_removed=$(expr $count_removed - 1) || true
+           count_removed=0
           fi
           if [ -z "$added" ]; then
-           count_added=$(expr $count_added - 1) || true
+           count_added=0
           fi
           echo removed:
           echo "$removed"


### PR DESCRIPTION
Changes `echo` to `printf` to avoid counting an extra line