### PR TITLE
Bumped versions for artifact and java-setup actions

### DIFF
--- a/.github/workflows/chebi.yml
+++ b/.github/workflows/chebi.yml
@@ -97,10 +97,10 @@ jobs:
           mkdir -p mapping_preprocessing/datasources/chebi/data
      # step 4: run the Java .jar for ChEBI preprocessing 
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       # Download current version from Zenodo
       #- name: Download current mapping file from Zenodo
       #  id: download_current_zenodo
@@ -218,7 +218,7 @@ jobs:
           echo "CHANGE=$change" >> $GITHUB_ENV 
 
       - name: 'Upload processed data as artifacts'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: chebi_processed
           path: datasources/chebi/recentData/*


### PR DESCRIPTION
The actions used Node 16 which will be deprecated for GitHub Actions