### PR TITLE
Updated upload-artifact to version 4

### DIFF
--- a/.github/workflows/ncbi.yml
+++ b/.github/workflows/ncbi.yml
@@ -189,7 +189,7 @@ jobs:
           echo "CHANGE=$change" >> $GITHUB_ENV 
       
       - name: 'Upload processed data as artifacts'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ncbi_processed
           path: datasources/ncbi/recentData/*


### PR DESCRIPTION
See original GitHub repo for action: https://github.com/actions/upload-artifact

```
actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. Learn more. Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions.
```

@tabbassidaloii @jmillanacosta please check :)