### PR TITLE
Added longer timeout restriction

### DIFF
--- a/.github/workflows/ncbi.yml
+++ b/.github/workflows/ncbi.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   check_new_data:
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # Consider increasing timeout
     name: Check the date of the latest data
     outputs:
       DATE_NEW: ${{ steps.check_download.outputs.DATE_NEW }}
@@ -47,6 +48,7 @@ jobs:
       DATE_OLD: ${{ needs.check_new_data.outputs.DATE_OLD }}
       DATE_NEW: ${{ needs.check_new_data.outputs.DATE_NEW }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # Consider increasing timeout
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ncbi.yml
+++ b/.github/workflows/ncbi.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   check_new_data:
     runs-on: ubuntu-latest
-    timeout-minutes: 10 # Consider increasing timeout
+    timeout-minutes: 20 # Consider increasing timeout
     name: Check the date of the latest data
     outputs:
       DATE_NEW: ${{ steps.check_download.outputs.DATE_NEW }}
@@ -48,7 +48,7 @@ jobs:
       DATE_OLD: ${{ needs.check_new_data.outputs.DATE_OLD }}
       DATE_NEW: ${{ needs.check_new_data.outputs.DATE_NEW }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10 # Consider increasing timeout
+    timeout-minutes: 20 # Consider increasing timeout
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ncbi.yml
+++ b/.github/workflows/ncbi.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   check_new_data:
     runs-on: ubuntu-latest
-    timeout-minutes: 20 # Consider increasing timeout
+    timeout-minutes: 10 # Consider increasing timeout
     name: Check the date of the latest data
     outputs:
       DATE_NEW: ${{ steps.check_download.outputs.DATE_NEW }}
@@ -48,7 +48,7 @@ jobs:
       DATE_OLD: ${{ needs.check_new_data.outputs.DATE_OLD }}
       DATE_NEW: ${{ needs.check_new_data.outputs.DATE_NEW }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20 # Consider increasing timeout
+    timeout-minutes: 30 # Consider increasing timeout
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub actions can timeout after 3 minutes, now enabled longer run (10 minutes) to try to get the job working

@tabbassidaloii