### PR TITLE
Fix typo in Java class name for ChEBI workflow

### DIFF
--- a/.github/workflows/chebi.yml
+++ b/.github/workflows/chebi.yml
@@ -162,7 +162,7 @@ jobs:
           cd ../
           outputDir="datasources/chebi/recentData/"
           # Run Java program and capture its exit code
-          java -cp java/target/mapping_prerocessing-0.0.1-jar-with-dependencies.jar org.sec2pri.chebi_sdf "$inputFile" "$outputDir" "${RELEASE_NUMBER}"
+          java -cp java/target/mapping_preprocessing-0.0.1-jar-with-dependencies.jar org.sec2pri.chebi_sdf "$inputFile" "$outputDir" "${RELEASE_NUMBER}"
           # Check the exit status of the Java program
           if [ $? -eq 0 ]; then
               # Java program succeeded


### PR DESCRIPTION
To be in line with https://github.com/sec2pri/mapping_preprocessing/commit/3410f554afe166f995b91314981a123fe8e75378